### PR TITLE
Support new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ $ composer require osushi/elasticsearch-orm:~{version}
 
 ### Version Metrics
 
-||Elasticsearch 5.6.x|Elasticsearch 6.2.x|Elasticsearch 6.3.x|Elasticsearch 6.4.x|Elasticsearch 6.5.x|
-|:---:|:---:|:---:|:---:|:---:|:---:|
-|Laravel 5.5.x|~5.6.0|~6.2.0|~6.3.0|~6.4.0|~6.5.0|
-|Laravel 5.6.x|~5.6.0|~6.2.0|~6.3.0|~6.4.0|~6.5.0|
-|Laravel 5.7.x|~5.6.0|~6.2.0|~6.3.0|~6.4.0|~6.5.0|
+||Elasticsearch 5.6.x|Elasticsearch 6.0.x|Elasticsearch 6.1.x|Elasticsearch 6.2.x|Elasticsearch 6.3.x|Elasticsearch 6.4.x|Elasticsearch 6.5.x|
+|:---:||:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|Laravel 5.5.x|~5.6.0|~6.0.0|~6.1.0|~6.2.0|~6.3.0|~6.4.0|~6.5.0|
+|Laravel 5.6.x|~5.6.0|~6.0.0|~6.1.0|~6.2.0|~6.3.0|~6.4.0|~6.5.0|
+|Laravel 5.7.x|~5.6.0|~6.0.0|~6.1.0|~6.2.0|~6.3.0|~6.4.0|~6.5.0|
 
 e.g.
 ```bash

--- a/docker/elasticsearch/6.0.1/docker-compose.yml
+++ b/docker/elasticsearch/6.0.1/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.0.1 # https://www.docker.elastic.co/
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - http.cors.enabled=true
+      - http.cors.allow-origin=*
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.watcher.enabled=false
+      - xpack.graph.enabled=false
+      - xpack.monitoring.history.duration=1d
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"

--- a/docker/elasticsearch/6.1.4/docker-compose.yml
+++ b/docker/elasticsearch/6.1.4/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.1.4 # https://www.docker.elastic.co/
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - http.cors.enabled=true
+      - http.cors.allow-origin=*
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.watcher.enabled=false
+      - xpack.graph.enabled=false
+      - xpack.monitoring.history.duration=1d
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"

--- a/src/Constants/Constant.php
+++ b/src/Constants/Constant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Osushi\ElasticsearchOrm\Constants;
+
+class Constant
+{
+    const ES_VERSION = 6.5;
+}

--- a/src/Queries/Aggregation/Aggregation.php
+++ b/src/Queries/Aggregation/Aggregation.php
@@ -122,4 +122,12 @@ class Aggregation implements Query
             $this->aggregations[$this->getName()]['top_hits']['_source'] = $columns;
         }
     }
+
+    public function nested(
+        string $path
+    ) {
+        $this->aggregations[$this->getName()]['nested'] = [
+            'path' => $path,
+        ];
+    }
 }

--- a/src/Queries/Query/Nested.php
+++ b/src/Queries/Query/Nested.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Osushi\ElasticsearchOrm\Queries\Query;
+
+use Osushi\ElasticsearchOrm\Queries\Query;
+
+class Nested implements Query
+{
+    const OPERATORS = [
+        '=', '!=', '>', '>=', '<', '<=',
+        'like'
+    ];
+
+    private $mode;
+
+    private $must = [];
+
+    private $filter = [];
+
+    public function mode(
+        string $mode
+    ) {
+        $this->mode = $mode;
+        return $this;
+    }
+
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    public function getMust()
+    {
+        return $this->must;
+    }
+
+    public function getFilter()
+    {
+        return $this->filter;
+    }
+
+    public function build(): array
+    {
+        $conditions = [];
+        if (count($this->must)) {
+            $conditions['bool']['must'] = $this->getMust();
+        }
+
+        if (count($this->filter)) {
+            $conditions['bool']['filter'] = $this->getFilter();
+        }
+
+        $this->mode = null;
+        $this->must = [];
+        $this->filter = [];
+
+        return $conditions;
+    }
+
+    public function where(
+        string $name,
+        string $operator = '=',
+        $value = null
+    ) {
+        if (!$this->isOperator($operator)) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        if ($operator === '=') {
+            $this->filter[] = [
+                'term' => [
+                    $name => $value
+                ],
+            ];
+        }
+
+        if ($operator === '>') {
+            $this->filter[] = [
+                'range' => [
+                    $name => ['gt' => $value],
+                ],
+            ];
+        }
+
+        if ($operator === '>=') {
+            $this->filter[] = [
+                'range' => [
+                    $name => ['gte' => $value],
+                ],
+            ];
+        }
+
+        if ($operator === '<') {
+            $this->filter[] = [
+                'range' => [
+                    $name => ['lt' => $value],
+                ],
+            ];
+        }
+
+        if ($operator === '<=') {
+            $this->filter[] = [
+                'range' => [
+                    $name => ['lte' => $value],
+                ],
+            ];
+        }
+
+        if ($operator === 'like') {
+            $this->must[] = [
+                'match' => [
+                    $name => $value,
+                ],
+            ];
+        }
+
+        return $this;
+    }
+
+    protected function isOperator(
+        string $operator
+    ) {
+        if (in_array($operator, self::OPERATORS)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Queries/Sort/Nested.php
+++ b/src/Queries/Sort/Nested.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Osushi\ElasticsearchOrm\Queries\Sort;
+
+use Osushi\ElasticsearchOrm\Queries\Query;
+
+class Nested implements Query
+{
+    const OPERATORS = [
+        '=', '!=', '>', '>=', '<', '<=',
+        'like'
+    ];
+
+    private $version;
+
+    private $path;
+
+    private $filter = [];
+
+    public function __construct(
+        float $version
+    ) {
+        $this->version = $version;
+    }
+
+    public function path(
+        string $path
+    ) {
+        $this->path = $path;
+        return $this;
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    public function getFilter()
+    {
+        return $this->filter;
+    }
+
+    public function build(): array
+    {
+        $conditions = [];
+        if (count($this->filter)) {
+            if ($this->version >= 6.1) {
+                if (!empty($this->getPath())) {
+                    $conditions['path'] = $this->getPath();
+                }
+                $conditions['filter'] = $this->getFilter();
+            } else {
+                if (!empty($this->getPath())) {
+                    $conditions['nested_path'] = $this->getPath();
+                }
+                $conditions['nested_filter'] = $this->getFilter();
+            }
+        }
+
+        $this->path = null;
+        $this->filter = [];
+
+        return $conditions;
+    }
+
+    public function where(
+        string $name,
+        string $operator = '=',
+        $value = null
+    ) {
+        if (!$this->isOperator($operator)) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        if ($operator === '=') {
+            $this->filter = [
+                'term' => [
+                    $name => $value
+                ],
+            ];
+        }
+
+        if ($operator === '>') {
+            $this->filter = [
+                'range' => [
+                    $name => ['gt' => $value],
+                ],
+            ];
+        }
+
+        if ($operator === '>=') {
+            $this->filter = [
+                'range' => [
+                    $name => ['gte' => $value],
+                ],
+            ];
+        }
+
+        if ($operator === '<') {
+            $this->filter = [
+                'range' => [
+                    $name => ['lt' => $value],
+                ],
+            ];
+        }
+
+        if ($operator === '<=') {
+            $this->filter = [
+                'range' => [
+                    $name => ['lte' => $value],
+                ],
+            ];
+        }
+
+        if ($operator === 'like') {
+            $this->filter = [
+                'match' => [
+                    $name => $value,
+                ],
+            ];
+        }
+
+        return $this;
+    }
+
+    protected function isOperator(
+        string $operator
+    ) {
+        if (in_array($operator, self::OPERATORS)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -305,6 +305,67 @@ class BuilderTest extends TestCase
             ['field1' => 'desc'],
             ['field2' => 'asc']
         ]);
+
+        $this->assertTrue($this->builder->orderBy('field3', 'desc', 'min') instanceof Builder);
+        $this->assertTrue($this->builder->getOrderBy() === [
+            ['field1' => 'desc'],
+            ['field2' => 'asc'],
+            [
+                'field3' => [
+                    'order' => 'desc',
+                    'mode' => 'min',
+                ],
+            ],
+        ]);
+    }
+
+    public function testOrderByNestAndGetOrderBy()
+    {
+        $builder = new Builder($this->client->build());
+        $this->assertTrue($builder->orderByNest('objects.field1', 'desc', 'min', function ($nest) {
+            $nest->path('objects')->where('objects.field2', '=', 1);
+        }, 6.5) instanceof Builder);
+        $this->assertEquals(
+            [
+                [
+                    'objects.field1' => [
+                        'order' => 'desc',
+                        'mode' => 'min',
+                        'nested' => [
+                            'path' => 'objects',
+                            'filter' => [
+                                'term' => [
+                                    'objects.field2' => 1
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getOrderBy()
+        );
+
+        $builder = new Builder($this->client->build());
+        $this->assertTrue($builder->orderByNest('objects.field1', 'desc', 'min', function ($nest) {
+            $nest->path('objects')->where('objects.field2', '=', 1);
+        }, 5.6) instanceof Builder);
+        $this->assertEquals(
+            [
+                [
+                    'objects.field1' => [
+                        'order' => 'desc',
+                        'mode' => 'min',
+                        'nested_path'=> 'objects',
+                        'nested_filter'=> [
+                            'term' => [
+                                'objects.field2' => 1
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getOrderBy()
+        );
     }
 
     public function testSelectAndGetSelect()
@@ -680,6 +741,39 @@ class BuilderTest extends TestCase
             $builder->getConditions()
         );
 
+        $builder = new Builder($this->client->build());
+        $builder->where('objects', 'nested', function ($nested) {
+            $nested->mode('avg')->where('objects.name', '=', 'name');
+        });
+        $this->assertEquals(
+            [
+                'query' => [
+                    'bool' => [
+                        'must' => [
+                            [
+                                'nested' => [
+                                    'score_mode' => 'avg',
+                                    'path' => 'objects',
+                                    'query' => [
+                                        'bool' => [
+                                            'filter' => [
+                                                [
+                                                    'term' => [
+                                                        'objects.name' => 'name',
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getConditions()
+        );
+
         // wherein
         $builder = new Builder($this->client->build());
         $builder->whereIn('field', [2]);
@@ -770,6 +864,16 @@ class BuilderTest extends TestCase
 
         $this->assertTrue($mock->isOperator('like'));
         $this->assertFalse($mock->isOperator('('));
+    }
+
+    public function testIsSortMode()
+    {
+        $mock = m::mock(new Builder($this->client->build()))
+              ->makePartial()
+              ->shouldAllowMockingProtectedMethods();
+
+        $this->assertTrue($mock->isSortMode('min'));
+        $this->assertFalse($mock->isSortMode('invalid'));
     }
 
     public function testExecute()

--- a/tests/Unit/Queries/Aggregation/AggregationTest.php
+++ b/tests/Unit/Queries/Aggregation/AggregationTest.php
@@ -104,6 +104,20 @@ class AggregationTest extends TestCase
         ], $aggs->getAggregations());
     }
 
+    public function testNested()
+    {
+        $aggs = new Aggregation('name');
+        $aggs->nested('path');
+
+        $this->assertEquals([
+            'name' => [
+                'nested' => [
+                    'path' => 'path',
+                ],
+            ],
+        ], $aggs->getAggregations());
+    }
+
     public function testBuild()
     {
         $aggs = new Aggregation('name');

--- a/tests/Unit/Queries/Query/NestedTest.php
+++ b/tests/Unit/Queries/Query/NestedTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Unit\Queries\Query;
+
+use Osushi\ElasticsearchOrm\Queries\Query\Nested;
+use Tests\TestCase;
+use Mockery as m;
+
+class NestedTest extends TestCase
+{
+    private $nested;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->nested = new Nested();
+    }
+
+    public function testModeAndGetMode()
+    {
+        $this->assertTrue($this->nested->mode('mode') instanceof Nested);
+        $this->assertTrue($this->nested->getMode() === 'mode');
+    }
+
+    public function testBuild_Where()
+    {
+        $this->assertTrue($this->nested->where('field', '=', 2) instanceof Nested);
+
+        // where
+        $nested = new Nested();
+        $nested->where('field', '=', 2);
+        $this->assertEquals(
+            [
+                'bool' => [
+                    'filter' => [
+                        [
+                            'term' => [
+                                'field' => 2,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested();
+        $nested->where('field', 2);
+        $this->assertEquals(
+            [
+                'bool' => [
+                    'filter' => [
+                        [
+                            'term' => [
+                                'field' => 2,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested();
+        $nested->where('field', '>', 2);
+        $this->assertEquals(
+            [
+                'bool' => [
+                    'filter' => [
+                        [
+                            'range' => [
+                                'field' => ['gt' => 2],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested();
+        $nested->where('field', '>=', 2);
+        $this->assertEquals(
+            [
+                'bool' => [
+                    'filter' => [
+                        [
+                            'range' => [
+                                'field' => ['gte' => 2],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested();
+        $nested->where('field', '<', 2);
+        $this->assertEquals(
+            [
+                'bool' => [
+                    'filter' => [
+                        [
+                            'range' => [
+                                'field' => ['lt' => 2],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested();
+        $nested->where('field', '<=', 2);
+        $this->assertEquals(
+            [
+                'bool' => [
+                    'filter' => [
+                        [
+                            'range' => [
+                                'field' => ['lte' => 2],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested();
+        $nested->where('field', 'like', 'test');
+        $this->assertEquals(
+            [
+                'bool' => [
+                    'must' => [
+                        [
+                            'match' => [
+                                'field' => 'test',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+
+        $this->assertEquals([], $nested->getFilter());
+        $this->assertEquals([], $nested->getMust());
+        $this->assertNull($nested->getMode());
+    }
+
+    public function testIsOperator()
+    {
+        $mock = m::mock(new Nested())
+              ->makePartial()
+              ->shouldAllowMockingProtectedMethods();
+
+        $this->assertTrue($mock->isOperator('like'));
+        $this->assertFalse($mock->isOperator('('));
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+}

--- a/tests/Unit/Queries/Sort/NestedTest.php
+++ b/tests/Unit/Queries/Sort/NestedTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Tests\Unit\Queries\Sort;
+
+use Osushi\ElasticsearchOrm\Queries\Sort\Nested;
+use Tests\TestCase;
+use Mockery as m;
+
+class NestedTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testPathAndGetPath()
+    {
+        $nested = new Nested(6.5);
+        $this->assertTrue($nested->path('path') instanceof Nested);
+        $this->assertTrue($nested->getPath() === 'path');
+    }
+
+    public function testBuild_Where()
+    {
+        // version >= 6.1
+        $nested = new Nested(6.5);
+        $nested->path('path');
+        $this->assertTrue($nested->where('field', '=', 2) instanceof Nested);
+        $this->assertEquals(
+            [
+                'path' => 'path',
+                'filter' => [
+                    'term' => [
+                        'field' => 2,
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(6.5);
+        $nested->where('field', '=', 2);
+        $this->assertEquals(
+            [
+                'filter' => [
+                    'term' => [
+                        'field' => 2,
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(6.5);
+        $nested->where('field', 2);
+        $this->assertEquals(
+            [
+                'filter' => [
+                    'term' => [
+                        'field' => 2,
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(6.5);
+        $nested->where('field', '>', 2);
+        $this->assertEquals(
+            [
+                'filter' => [
+                    'range' => [
+                        'field' => ['gt' => 2],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(6.5);
+        $nested->where('field', '>=', 2);
+        $this->assertEquals(
+            [
+                'filter' => [
+                    'range' => [
+                        'field' => ['gte' => 2],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(6.5);
+        $nested->where('field', '<', 2);
+        $this->assertEquals(
+            [
+                'filter' => [
+                    'range' => [
+                        'field' => ['lt' => 2],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(6.5);
+        $nested->where('field', '<=', 2);
+        $this->assertEquals(
+            [
+                'filter' => [
+                    'range' => [
+                        'field' => ['lte' => 2],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(6.5);
+        $nested->where('field', 'like', 'test');
+        $this->assertEquals(
+            [
+                'filter' => [
+                    'match' => [
+                        'field' => 'test',
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        // version < 6.1
+        $nested = new Nested(5.6);
+        $nested->path('path');
+        $this->assertTrue($nested->where('field', '=', 2) instanceof Nested);
+        $this->assertEquals(
+            [
+                'nested_path' => 'path',
+                'nested_filter' => [
+                    'term' => [
+                        'field' => 2,
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(5.6);
+        $nested->where('field', '=', 2);
+        $this->assertEquals(
+            [
+                'nested_filter' => [
+                    'term' => [
+                        'field' => 2,
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(5.6);
+        $nested->where('field', 2);
+        $this->assertEquals(
+            [
+                'nested_filter' => [
+                    'term' => [
+                        'field' => 2,
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(5.6);
+        $nested->where('field', '>', 2);
+        $this->assertEquals(
+            [
+                'nested_filter' => [
+                    'range' => [
+                        'field' => ['gt' => 2],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(5.6);
+        $nested->where('field', '>=', 2);
+        $this->assertEquals(
+            [
+                'nested_filter' => [
+                    'range' => [
+                        'field' => ['gte' => 2],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(5.6);
+        $nested->where('field', '<', 2);
+        $this->assertEquals(
+            [
+                'nested_filter' => [
+                    'range' => [
+                        'field' => ['lt' => 2],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(5.6);
+        $nested->where('field', '<=', 2);
+        $this->assertEquals(
+            [
+                'nested_filter' => [
+                    'range' => [
+                        'field' => ['lte' => 2],
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $nested = new Nested(5.6);
+        $nested->where('field', 'like', 'test');
+        $this->assertEquals(
+            [
+                'nested_filter' => [
+                    'match' => [
+                        'field' => 'test',
+                    ],
+                ],
+            ],
+            $nested->build()
+        );
+
+        $this->assertEquals([], $nested->getFilter());
+        $this->assertNull($nested->getPath());
+    }
+
+    public function testIsOperator()
+    {
+        $mock = m::mock(new Nested(6.5))
+              ->makePartial()
+              ->shouldAllowMockingProtectedMethods();
+
+        $this->assertTrue($mock->isOperator('like'));
+        $this->assertFalse($mock->isOperator('('));
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+}


### PR DESCRIPTION
### Support Elasticsearch versions
`6.0` , `6.1`

### Support sort mode
```php
orderBy('created_at', 'desc', '{mode}')
```

### Support nested query
```php
where('{path}', 'nested', function($query){
  $query->mode('{mode}')->where('{field}', '{operator}', '{value}');
})
```

### Support nested aggregation
```php
nested(string $path)
```

### Support nested sorting
```php
orderByNest('{field}', '{order}', '{mode}', function ($nested) {
  $nested->path('{path}')->where('{field}', '{operator}', '{value}');
})
```