### PR TITLE
Support between adn query option method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ composer.phar
 composer.lock
 composer-*.lock
 test.sh
+deploy.sh
 /vendor
 /tmp
 


### PR DESCRIPTION
### Support between query
```php
matchBetween(
  string $name,
  array $range,
  array $equals = [false, false]
)

whereBetween(
  string $name,
  array $range,
  array $equals = [false, false]
)

orWhereBetween(
  string $name,
  array $range,
  array $equals = [false, false]
)

notWhereBetween(
  string $name,
  array $range,
  array $equals = [false, false]
)
```

### Support query option
```php
queryOption(
  string $name,
  $value = null
)
```
